### PR TITLE
Add AST structure and visualization

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "next": "15.3.2",
         "next-themes": "^0.4.6",
         "react": "19.1.0",
+        "react-d3-tree": "^3.6.6",
         "react-dom": "19.1.0",
         "react-hook-form": "^7.56.3",
         "react-phone-number-input": "^3.4.12",
@@ -148,6 +149,8 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+
+    "@bkrem/react-transition-group": ["@bkrem/react-transition-group@1.3.5", "", { "dependencies": { "chain-function": "^1.0.0", "dom-helpers": "^3.3.1", "loose-envify": "^1.3.1", "prop-types": "^15.5.6", "react-lifecycles-compat": "^3.0.4", "warning": "^3.0.0" }, "peerDependencies": { "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-lbBYhC42sxAeFEopxzd9oWdkkV0zirO5E9WyeOBxOrpXsf7m30Aj8vnbayZxFOwD9pvUQ2Pheb1gO79s0Qap3Q=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.4.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ=="],
 
@@ -421,6 +424,8 @@
 
     "@types/bun": ["@types/bun@1.2.13", "", { "dependencies": { "bun-types": "1.2.13" } }, "sha512-u6vXep/i9VBxoJl3GjZsl/BFIsvML8DfVDO0RYLEwtSZSp981kEO1V5NwRcO1CPJ7AmvpbnDCiMKo3JvbDEjAg=="],
 
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@1.1.11", "", {}, "sha512-lnQiU7jV+Gyk9oQYk0GGYccuexmQPTp08E0+4BidgFdiJivjEvf+esPSdZqCZ2C7UwTWejWpqetVaU8A+eX3FA=="],
+
     "@types/graceful-fs": ["@types/graceful-fs@4.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ=="],
 
     "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
@@ -495,6 +500,8 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001646", "", {}, "sha512-dRg00gudiBDDTmUhClSdv3hqRfpbOnU28IpI1T6PBTLWa+kOj0681C8uML3PifYfREuBrVjDGhL3adYpBT6spw=="],
 
+    "chain-function": ["chain-function@1.0.1", "", {}, "sha512-SxltgMwL9uCko5/ZCLiyG2B7R9fY4pDZUw7hJ4MhirdjBLosoDqkWABi3XMucddHdLiFJMb7PD2MZifZriuMTg=="],
+
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
@@ -512,6 +519,8 @@
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "clone": ["clone@2.1.2", "", {}, "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -545,6 +554,30 @@
 
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-hierarchy": ["d3-hierarchy@1.1.9", "", {}, "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
     "debug": ["debug@4.3.6", "", { "dependencies": { "ms": "2.1.2" } }, "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg=="],
 
     "dedent": ["dedent@1.5.3", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ=="],
@@ -562,6 +595,8 @@
     "diff-sequences": ["diff-sequences@29.6.3", "", {}, "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "dom-helpers": ["dom-helpers@3.4.0", "", { "dependencies": { "@babel/runtime": "^7.1.2" } }, "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.4", "", {}, "sha512-orzA81VqLyIGUEA77YkVA1D+N+nNfl2isJVjjmOyrlxuooZ19ynb+dOlaDTqd/idKRS9lDCSBmtzM+kyCsMnkA=="],
 
@@ -885,11 +920,15 @@
 
     "react": ["react@19.1.0", "", {}, "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg=="],
 
+    "react-d3-tree": ["react-d3-tree@3.6.6", "", { "dependencies": { "@bkrem/react-transition-group": "^1.3.5", "@types/d3-hierarchy": "^1.1.8", "clone": "^2.1.1", "d3-hierarchy": "^1.1.9", "d3-selection": "^3.0.0", "d3-shape": "^1.3.7", "d3-zoom": "^3.0.0", "dequal": "^2.0.2", "uuid": "^8.3.1" }, "peerDependencies": { "react": "16.x || 17.x || 18.x || 19.x", "react-dom": "16.x || 17.x || 18.x || 19.x" } }, "sha512-E9ByUdeqvlxLlF9BSL7KWQH3ikYHtHO+g1rAPcVgj6mu92tjRUCan2AWxoD4eTSzzAATf8BZtf+CXGSoSd6ioQ=="],
+
     "react-dom": ["react-dom@19.1.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g=="],
 
     "react-hook-form": ["react-hook-form@7.56.3", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-IK18V6GVbab4TAo1/cz3kqajxbDPGofdF0w7VHdCo0Nt8PrPlOZcuuDq9YYIV1BtjcX78x0XsldbQRQnQXWXmw=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "react-lifecycles-compat": ["react-lifecycles-compat@3.0.4", "", {}, "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="],
 
     "react-phone-number-input": ["react-phone-number-input@3.4.12", "", { "dependencies": { "classnames": "^2.5.1", "country-flag-icons": "^1.5.17", "input-format": "^0.3.10", "libphonenumber-js": "^1.11.20", "prop-types": "^15.8.1" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-Raob77KdtLGm49iC6nuOX9qy6Mg16idkgC7Y1mHmvG2WBYoauHpzxYNlfmFskQKeiztrJIwPhPzBhjFwjenNCA=="],
 
@@ -1012,6 +1051,8 @@
     "v8-to-istanbul": ["v8-to-istanbul@9.3.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.12", "@types/istanbul-lib-coverage": "^2.0.1", "convert-source-map": "^2.0.0" } }, "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA=="],
 
     "walker": ["walker@1.0.8", "", { "dependencies": { "makeerror": "1.0.12" } }, "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ=="],
+
+    "warning": ["warning@3.0.0", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-jMBt6pUrKn5I+OGgtQ4YZLdhIeJmObddh6CsibPxyQ5yPZm1XExSyzC1LCNX7BzhxWgiHmizBWJTHJIjMjTQYQ=="],
 
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"next": "15.3.2",
 		"next-themes": "^0.4.6",
 		"react": "19.1.0",
+		"react-d3-tree": "^3.6.6",
 		"react-dom": "19.1.0",
 		"react-hook-form": "^7.56.3",
 		"react-phone-number-input": "^3.4.12",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
-/*
- * @returns Home page component
- */
-export default async function Home() {
-	return "HELLO WORLD";
+import { PascalCompiler } from "@/components/pascal-compiler";
+
+export default function Home() {
+  return <PascalCompiler />;
 }

--- a/src/components/ast-tree.tsx
+++ b/src/components/ast-tree.tsx
@@ -1,0 +1,43 @@
+"use client";
+import dynamic from "next/dynamic";
+import { CSSProperties } from "react";
+import type { AST, ASTNode } from "@/lib/ast";
+
+const Tree = dynamic(() => import("react-d3-tree").then(mod => mod.Tree), {
+  ssr: false,
+});
+
+function astNodeToTree(node: ASTNode, label?: string) {
+  const name = label ? `${node.kind} (${label})` : node.kind;
+  const attributes: Record<string, string> = {};
+  const children: any[] = [];
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "kind") continue;
+    if (Array.isArray(value)) {
+      if (value.length > 0 && typeof value[0] === "object" && value[0] && "kind" in value[0]) {
+        children.push({ name: key, children: value.map((v) => astNodeToTree(v as ASTNode)) });
+      } else if (value.length > 0) {
+        attributes[key] = JSON.stringify(value);
+      }
+    } else if (value && typeof value === "object" && "kind" in value) {
+      children.push(astNodeToTree(value as ASTNode, key));
+    } else if (value !== undefined) {
+      attributes[key] = String(value);
+    }
+  }
+
+  return { name, attributes, children };
+}
+
+export function ASTTree({ ast }: { ast: AST }) {
+  if (!ast.root) return null;
+  const data = astNodeToTree(ast.root);
+  const containerStyles: CSSProperties = { width: "100%", height: "500px" };
+  return (
+    <div style={containerStyles} className="border rounded-md bg-muted/50">
+      <Tree data={data} orientation="vertical" pathFunc="elbow" />
+    </div>
+  );
+}
+

--- a/src/components/pascal-compiler.tsx
+++ b/src/components/pascal-compiler.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { compilePascal, CompilationResult } from "@/lib/mock-api";
+import { SubmitButton } from "@/components/submit-button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ModeToggle } from "@/components/mode-toogle";
+import { Textarea } from "@/components/ui/textarea";
+import { ASTTree } from "@/components/ast-tree";
+
+export function PascalCompiler() {
+  const [code, setCode] = useState("");
+  const [result, setResult] = useState<CompilationResult | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    const res = await compilePascal(code);
+    setResult(res);
+    setLoading(false);
+  }
+
+  return (
+    <div className="container mx-auto max-w-4xl py-10 space-y-6">
+      <div className="flex justify-end"><ModeToggle /></div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Pascal Playground</CardTitle>
+          <CardDescription>Enter your Pascal code and compile it</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={onSubmit} className="space-y-4">
+            <Textarea
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder="begin\n  writeln('Hello World');\nend."
+              className="min-h-[180px]"
+            />
+            <SubmitButton isSubmitting={loading}>Compile</SubmitButton>
+          </form>
+        </CardContent>
+      </Card>
+
+      {result && (
+        <div className="grid gap-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Tokens</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="text-sm font-mono space-y-1">
+                {result.tokens.map((t, i) => (
+                  <li key={i} className="flex justify-between border-b last:border-none py-1">
+                    <span className="font-semibold">{t.token_name}</span>
+                    <span className="text-muted-foreground">{t.token_content}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>AST</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ASTTree ast={result.ast} />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>ASM Code</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <pre className="whitespace-pre-wrap text-sm font-mono">{result.asm}</pre>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Output</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <pre className="whitespace-pre-wrap text-sm font-mono">{result.output}</pre>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/src/lib/ast.ts
+++ b/src/lib/ast.ts
@@ -1,0 +1,235 @@
+export enum BasicType {
+  Integer = 'Integer',
+  LongInt = 'LongInt',
+  UnsignedInt = 'UnsignedInt',
+  Real = 'Real',
+  String = 'String',
+}
+
+export enum NodeKind {
+  Program = 'Program',
+  Block = 'Block',
+  VarDecl = 'VarDecl',
+  TypeDecl = 'TypeDecl',
+  ConstDecl = 'ConstDecl',
+  ProcedureDecl = 'ProcedureDecl',
+  FunctionDecl = 'FunctionDecl',
+  ParamDecl = 'ParamDecl',
+  CompoundStmt = 'CompoundStmt',
+  AssignStmt = 'AssignStmt',
+  ProcCall = 'ProcCall',
+  IfStmt = 'IfStmt',
+  WhileStmt = 'WhileStmt',
+  ForStmt = 'ForStmt',
+  RepeatStmt = 'RepeatStmt',
+  CaseStmt = 'CaseStmt',
+  WithStmt = 'WithStmt',
+  BinaryExpr = 'BinaryExpr',
+  UnaryExpr = 'UnaryExpr',
+  LiteralExpr = 'LiteralExpr',
+  VariableExpr = 'VariableExpr',
+  Range = 'Range',
+  TypeSpec = 'TypeSpec',
+  SimpleTypeSpec = 'SimpleTypeSpec',
+  ArrayTypeSpec = 'ArrayTypeSpec',
+  RecordTypeSpec = 'RecordTypeSpec',
+  PointerTypeSpec = 'PointerTypeSpec',
+  CaseLabel = 'CaseLabel',
+  NewExpr = 'NewExpr',
+  DisposeExpr = 'DisposeExpr',
+}
+
+export interface ASTNode {
+  kind: NodeKind;
+}
+
+export interface Expression extends ASTNode {}
+export interface Statement extends ASTNode {}
+export interface Declaration extends ASTNode {}
+
+export interface Program extends ASTNode {
+  kind: NodeKind.Program;
+  name: string;
+  block: Block;
+}
+
+export interface Block extends ASTNode {
+  kind: NodeKind.Block;
+  declarations: Declaration[];
+  statements: Statement[];
+}
+
+export interface VarDecl extends Declaration {
+  kind: NodeKind.VarDecl;
+  names: string[];
+  type: TypeSpec;
+}
+
+export interface ConstDecl extends Declaration {
+  kind: NodeKind.ConstDecl;
+  name: string;
+  value: Expression;
+}
+
+export interface TypeDecl extends Declaration {
+  kind: NodeKind.TypeDecl;
+  name: string;
+  type: TypeSpec;
+}
+
+export interface ProcedureDecl extends Declaration {
+  kind: NodeKind.ProcedureDecl;
+  name: string;
+  params: ParamDecl[];
+  body: Block;
+}
+
+export interface ParamDecl extends Declaration {
+  kind: NodeKind.ParamDecl;
+  names: string[];
+  type: TypeSpec;
+}
+
+export interface FunctionDecl extends Declaration {
+  kind: NodeKind.FunctionDecl;
+  name: string;
+  params: ParamDecl[];
+  returnType: TypeSpec;
+  body: Block;
+}
+
+export interface CompoundStmt extends Statement {
+  kind: NodeKind.CompoundStmt;
+  statements: Statement[];
+}
+
+export interface AssignStmt extends Statement {
+  kind: NodeKind.AssignStmt;
+  target: Expression;
+  value: Expression;
+}
+
+export interface ProcCall extends Statement {
+  kind: NodeKind.ProcCall;
+  name: string;
+  args: Expression[];
+}
+
+export interface IfStmt extends Statement {
+  kind: NodeKind.IfStmt;
+  condition: Expression;
+  thenBranch: Statement;
+  elseBranch?: Statement;
+}
+
+export interface WhileStmt extends Statement {
+  kind: NodeKind.WhileStmt;
+  condition: Expression;
+  body: Statement;
+}
+
+export interface ForStmt extends Statement {
+  kind: NodeKind.ForStmt;
+  init: AssignStmt;
+  downto: boolean;
+  limit: Expression;
+  body: Statement;
+}
+
+export interface RepeatStmt extends Statement {
+  kind: NodeKind.RepeatStmt;
+  body: Statement[];
+  condition: Expression;
+}
+
+export interface CaseStmt extends Statement {
+  kind: NodeKind.CaseStmt;
+  expr: Expression;
+  cases: CaseLabel[];
+}
+
+export interface WithStmt extends Statement {
+  kind: NodeKind.WithStmt;
+  recordExpr: Expression;
+  body: Statement;
+}
+
+export interface BinaryExpr extends Expression {
+  kind: NodeKind.BinaryExpr;
+  left: Expression;
+  op: string;
+  right: Expression;
+}
+
+export interface UnaryExpr extends Expression {
+  kind: NodeKind.UnaryExpr;
+  op: string;
+  operand: Expression;
+}
+
+export interface LiteralExpr extends Expression {
+  kind: NodeKind.LiteralExpr;
+  value: string;
+}
+
+export type Selector =
+  | { kind: 'Field'; field: string }
+  | { kind: 'Index'; index: Expression }
+  | { kind: 'Pointer' };
+
+export interface VariableExpr extends Expression {
+  kind: NodeKind.VariableExpr;
+  name: string;
+  selectors: Selector[];
+}
+
+export interface Range extends ASTNode {
+  kind: NodeKind.Range;
+  start: number;
+  end: number;
+}
+
+export interface TypeSpec extends ASTNode {}
+
+export interface SimpleTypeSpec extends TypeSpec {
+  kind: NodeKind.SimpleTypeSpec;
+  basic: BasicType;
+  name?: string;
+}
+
+export interface ArrayTypeSpec extends TypeSpec {
+  kind: NodeKind.ArrayTypeSpec;
+  ranges: Range[];
+  elementType: TypeSpec;
+}
+
+export interface RecordTypeSpec extends TypeSpec {
+  kind: NodeKind.RecordTypeSpec;
+  fields: VarDecl[];
+}
+
+export interface PointerTypeSpec extends TypeSpec {
+  kind: NodeKind.PointerTypeSpec;
+  refType: TypeSpec;
+}
+
+export interface CaseLabel extends ASTNode {
+  kind: NodeKind.CaseLabel;
+  constants: Expression[];
+  stmt: Statement;
+}
+
+export interface NewExpr extends Expression {
+  kind: NodeKind.NewExpr;
+  variable: VariableExpr;
+}
+
+export interface DisposeExpr extends Expression {
+  kind: NodeKind.DisposeExpr;
+  variable: VariableExpr;
+}
+
+export interface AST {
+  root: Program | null;
+  valid: boolean;
+}

--- a/src/lib/mock-api.ts
+++ b/src/lib/mock-api.ts
@@ -1,0 +1,50 @@
+import { AST, NodeKind } from "./ast";
+
+export interface CompilationResult {
+  tokens: { token_name: string; token_content: string }[];
+  ast: AST;
+  asm: string;
+  output: string;
+}
+
+export async function compilePascal(code: string): Promise<CompilationResult> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const parts = code.split(/\s+/).filter(Boolean);
+      const tokens = parts.map((t, i) => ({ token_name: `TOKEN_${i}`, token_content: t }));
+
+      const ast: AST = {
+        valid: true,
+        root: {
+          kind: NodeKind.Program,
+          name: "MockProgram",
+          block: {
+            kind: NodeKind.Block,
+            declarations: [],
+            statements: [
+              {
+                kind: NodeKind.CompoundStmt,
+                statements: [
+                  {
+                    kind: NodeKind.ProcCall,
+                    name: "writeln",
+                    args: [
+                      { kind: NodeKind.LiteralExpr, value: "Hello World" },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      };
+
+      resolve({
+        tokens,
+        ast,
+        asm: '; mocked ASM code\nMOV AX, BX',
+        output: 'mocked output',
+      });
+    }, 1000);
+  });
+}


### PR DESCRIPTION
## Summary
- install `react-d3-tree`
- implement AST type definitions
- extend mock API to return a sample AST
- add `ASTTree` component for graphical display
- render AST visualization in the playground

## Testing
- `bun test`
- `bun run lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68622f1fc2908330987ddd4b093fc19e